### PR TITLE
Improve package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+Tests               export-ignore
+vendor              export-ignore
+.*                  export-ignore
+phpstan.neon        export-ignore
+phpunit.xml         export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,25 @@ language: php
 php:
     - 7.0
     - 7.1
+    - 7.2
 
 cache:
     directories:
-        - $HOME/.composer/cache
+        - $HOME/.composer/cache/files
 
-before_script:
-    - composer selfupdate
-    - composer update --prefer-dist --no-interaction
+before_install:
+    - phpenv config-rm xdebug.ini
+
+install: 
+    - composer update --prefer-dist --prefer-stable --no-interaction
 
 script:
     - vendor/bin/phpstan analyse -l 7 -c phpstan.neon src Tests
     - vendor/bin/phpunit
+
+jobs:
+  include:
+    - stage: Test
+      php: 7.0
+      env: PREFER_LOWEST=true
+      install: composer update --prefer-lowest --prefer-dist --prefer-stable --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,10 @@
             "email": "jan@jangregor.me"
         }
     ],
-    "require": {},
-    "require-dev": {
+    "require": {
         "phpspec/prophecy": "^1.7",
-        "phpunit/phpunit": "^6.4",
-        "phpstan/phpstan": "0.9.x-dev"
+        "phpunit/phpunit": "^6.0",
+        "phpstan/phpstan": "^0.9"
     },
     "autoload": {
         "psr-4": {

--- a/src/Extension/ProphetProphesizeDynamicReturnTypeExtension.php
+++ b/src/Extension/ProphetProphesizeDynamicReturnTypeExtension.php
@@ -52,8 +52,6 @@ class ProphetProphesizeDynamicReturnTypeExtension implements DynamicMethodReturn
             $class = $scope->getClassReflection()->getName();
         }
 
-        $ObjectProphecyType = new ObjectProphecyType($class);
-
-        return $ObjectProphecyType;
+        return new ObjectProphecyType($class);
     }
 }


### PR DESCRIPTION
First off, thanks for creating this extension, it works really well!!

I took the time to do some improvements:

 * Updated composer.json
    * all requirements are non-dev: those are the dependencies of this lib, they must be hard requirements! Otherwise I will be able to require this lib alongside (for example) PHPStan 0.8, and that will not work!
    * PHPUnit requirement is relaxed to the whole 6 series: we're not using anything that requires a higher version, except PHPStan itself, which will handle it in its requirements
    * PHPStan requirement is now `^0.9`, since we got it tagged! :tada: 
 * Added `.gitattributes`: this reduces the number of files that are distributed with this lib through Composer
 * Improved the Travis build:
    * added PHP 7.2 :tada: 
    * added a job to test with `--prefer-lowest`
    * removed `composer self-update`, Travis does this on its own
    * changed caching: we need to cache composer files, not package definitions, or we could miss new lib releases!
    * disabled xdebug to have a faster build

I hope that after this gets merged, we can tag the first 0.1 release, what do you think? :smile: 