### PR TITLE
Fix extension definition

### DIFF
--- a/src/extension.neon
+++ b/src/extension.neon
@@ -16,5 +16,4 @@ services:
 	-
 		class: JanGregor\Prophecy\Reflection\ProphecyMethodsClassReflectionExtension
 		tags:
-			- phpstan.broker.propertiesClassReflectionExtension
 			- phpstan.broker.methodsClassReflectionExtension


### PR DESCRIPTION
`ProphecyMethodsClassReflectionExtension` does not implement the `PropertiesClassReflectionExtension` interface.

This fixes this extension, it was broken on my project.