### PR TITLE
Update for compatibility with unreleased PHPStan version 0.10.x

### DIFF
--- a/src/Reflection/ObjectProphecyMethodReflection.php
+++ b/src/Reflection/ObjectProphecyMethodReflection.php
@@ -3,6 +3,7 @@
 namespace JanGregor\Prophecy\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ClassMethodReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Type\ObjectType;
@@ -70,7 +71,7 @@ class ObjectProphecyMethodReflection implements MethodReflection
         return new ObjectType(MethodProphecy::class);
     }
 
-    public function getPrototype(): MethodReflection
+    public function getPrototype(): ClassMethodReflection
     {
         return $this;
     }

--- a/src/Reflection/ObjectProphecyMethodReflection.php
+++ b/src/Reflection/ObjectProphecyMethodReflection.php
@@ -3,8 +3,8 @@
 namespace JanGregor\Prophecy\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ClassMethodReflection;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -71,7 +71,7 @@ class ObjectProphecyMethodReflection implements MethodReflection
         return new ObjectType(MethodProphecy::class);
     }
 
-    public function getPrototype(): ClassMethodReflection
+    public function getPrototype(): ClassMemberReflection
     {
         return $this;
     }


### PR DESCRIPTION
Method return type has changed for `MethodReflection:getPrototype()`.

phpstan/phpstan@8dd51d7