### PR TITLE
Fix: Add description to composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 before_install:
     - phpenv config-rm xdebug.ini
+    - composer validate
 
 install: 
     - composer update --prefer-dist --prefer-stable --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "jangregor/phpstan-prophecy",
+    "description": "Provides a phpstan/phpstan extension for phpspec/prophecy",
     "authors": [
         {
             "name": "Jan Gregor Emge-Triebel",


### PR DESCRIPTION
This PR

* [x] validates `composer.json` on Travis CI
* [x] provides a description in `composer.json`

💁‍♂️ Running

```
$ composer validate
```

on current `master` yields

```
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
description : The property description is required
No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
```

❗️Also note that currently, license information is missing:

![screen shot 2018-06-24 at 01 18 38](https://user-images.githubusercontent.com/605483/41817513-c9dcf448-779c-11e8-9e7d-fd2cb9b3e5cb.png)
