### PR TITLE
Fix: Use max level instead of 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     - composer update --prefer-dist --prefer-stable --no-interaction
 
 script:
-    - vendor/bin/phpstan analyse -l 7 -c phpstan.neon src tests
+    - vendor/bin/phpstan analyse -l max -c phpstan.neon src tests
     - vendor/bin/phpunit
 
 jobs:


### PR DESCRIPTION
This PR

* [x] runs `phpstan` with level `max` instead of `7`