### PR TITLE
Add license indication in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "jangregor/phpstan-prophecy",
     "description": "Provides a phpstan/phpstan extension for phpspec/prophecy",
+    "license": "MIT",
     "authors": [
         {
             "name": "Jan Gregor Emge-Triebel",


### PR DESCRIPTION
Since the license was added in 61facf7b6aa0328e800905ed1139240a5c7e4733, we should publish the same info on Packagist through this modification.