### PR TITLE
Fix: Indent YML files with 2 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ trim_trailing_whitespace = true
 
 [*.neon]
 indent_style = tab
+
+[*.yml]
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,28 @@
 language: php
 
 php:
-    - 7.0
-    - 7.1
-    - 7.2
+  - 7.0
+  - 7.1
+  - 7.2
 
 cache:
-    directories:
-        - $HOME/.composer/cache/files
+  directories:
+    - $HOME/.composer/cache/files
 
 before_install:
-    - phpenv config-rm xdebug.ini
-    - composer validate
+  - phpenv config-rm xdebug.ini
+  - composer validate
 
 install:
-    - composer update --prefer-dist --prefer-stable --no-interaction
+  - composer update --prefer-dist --prefer-stable --no-interaction
 
 script:
-    - vendor/bin/phpstan analyse -l max -c phpstan.neon src tests
-    - vendor/bin/phpunit
+  - vendor/bin/phpstan analyse -l max -c phpstan.neon src tests
+  - vendor/bin/phpunit
 
 jobs:
-    include:
-        - stage: Test
-            php: 7.0
-            env: PREFER_LOWEST=true
-            install: composer update --prefer-lowest --prefer-dist --prefer-stable --no-interaction
+  include:
+    - stage: Test
+      php: 7.0
+      env: PREFER_LOWEST=true
+      install: composer update --prefer-lowest --prefer-dist --prefer-stable --no-interaction


### PR DESCRIPTION
This PR

* [x] indents YML files with 2 spaces

Slightly related to https://github.com/Jan0707/phpstan-prophecy/pull/9#issuecomment-403722434.