### PR TITLE
Enhancement: Run tests against lowest, locked, and highest dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ trim_trailing_whitespace = true
 
 [*.neon]
 indent_style = tab
+
+[*.yml]
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,87 @@
 language: php
 
-php:
-    - 7.0
-    - 7.1
-    - 7.2
-
 cache:
-    directories:
-        - $HOME/.composer/cache/files
+  directories:
+    - $HOME/.composer/cache/files
 
-before_install:
-    - phpenv config-rm xdebug.ini
-    - composer validate
-
-install:
-    - composer update --prefer-dist --prefer-stable --no-interaction
-
-script:
-    - vendor/bin/phpstan analyse -l max -c phpstan.neon src tests
-    - vendor/bin/phpunit
+stages:
+  - stan
+  - test
 
 jobs:
-    include:
-        - stage: Test
-            php: 7.0
-            env: PREFER_LOWEST=true
-            install: composer update --prefer-lowest --prefer-dist --prefer-stable --no-interaction
+  include:
+    - stage: Stan
+
+      php: 7.2
+
+      install:
+        - composer install
+
+      script:
+        - vendor/bin/phpstan analyse -l max -c phpstan.neon src tests
+
+    - &TEST
+
+      stage: Test
+
+      php: 7.0
+
+      env: WITH_LOWEST=true
+
+      install:
+        - if [[ "$WITH_LOWEST" == "true" ]]; then composer update --prefer-lowest; fi
+        - if [[ "$WITH_LOCKED" == "true" ]]; then composer install; fi
+        - if [[ "$WITH_HIGHEST" == "true" ]]; then composer update; fi
+
+      script:
+        - vendor/bin/phpunit
+
+    - <<: *TEST
+
+      php: 7.0
+
+      env: WITH_LOCKED=true
+
+    - <<: *TEST
+
+      php: 7.0
+
+      env: WITH_HIGHEST=true
+
+    - <<: *TEST
+
+      php: 7.1
+
+      env: WITH_LOWEST=true
+
+    - <<: *TEST
+
+      php: 7.1
+
+      env: WITH_LOCKED=true
+
+    - <<: *TEST
+
+      php: 7.1
+
+      env: WITH_HIGHEST=true
+
+    - <<: *TEST
+
+      php: 7.2
+
+      env: WITH_LOWEST=true
+
+    - <<: *TEST
+
+      php: 7.2
+
+      env: WITH_LOCKED=true
+
+    - <<: *TEST
+
+      php: 7.2
+
+      env: WITH_HIGHEST=true
+
+


### PR DESCRIPTION
This PR

* [x] configures Travis CI stages (`stan` and `test`) and runs tests against lowest, locked, and highest versions of dependencies

Follows https://github.com/Jan0707/phpstan-prophecy/pull/9#issuecomment-403722434.

💁‍♂️ For reference, see https://docs.travis-ci.com/user/build-stages/.