### PR TITLE
Enhancement: Trigger syntax highlighting in fenced code blocks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ This repository provides an extension so that it also understands code that uses
 
 ### Prophesizing and Revealing
 
-```
+```php
 $prophecy = $prophet->prophesize(SomeModel::class);
 $instance = $prophecy->reveal();
 ```
@@ -19,7 +19,7 @@ It will help PHPStan to understand that the `$instance` variable is indeed an in
 
 ### Method Predictions
 
-```
+```php
 $prophecy = $prophet->prophesize(Calculator::class);
 $prophecy->doubleTheNumber(Argument::is(2))->willReturn(5);
 
@@ -35,13 +35,13 @@ It will also help PHPStan to understand that `$prophecy` accepts method calls to
 
 Install via composer (no release available yet):
 
-```
+```shell
 composer require --dev jangregor/phpstan-prophecy
 ```
 
 And then make sure to add the extension to your `phpstan.neon` file:
 
-```
+```neon
 includes:
 	- vendor/jangregor/phpstan-prophecy/src/extension.neon
 ```


### PR DESCRIPTION
This PR

* [x] triggers syntax highlighting in fenced code blocks

💁‍♂️ For reference, see https://help.github.com/articles/creating-and-highlighting-code-blocks. 

Note that this also helps a lot when using PhpStorm:

### Before

<img width="1792" alt="screen shot 2018-10-26 at 16 26 54" src="https://user-images.githubusercontent.com/605483/47572814-2497e680-d93c-11e8-98f7-8ddddeacbd1d.png">

### After

<img width="1792" alt="screen shot 2018-10-26 at 16 27 04" src="https://user-images.githubusercontent.com/605483/47572825-2bbef480-d93c-11e8-858f-177d8e28aac4.png">

