### PR TITLE
Fix: Remove invalid note about unavailability of release

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ It will also help PHPStan to understand that `$prophecy` accepts method calls to
 
 ## Installation and usage
 
-Install via composer (no release available yet):
+Install via composer:
 
 ```
 composer require --dev jangregor/phpstan-prophecy


### PR DESCRIPTION
This PR

* [x] removes an invalid note about unavailability of release from `readme.md`

💁‍♂️ Also see https://github.com/Jan0707/phpstan-prophecy/releases.