### PR TITLE
Fix: Also run build with locked dependencies on PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,12 @@ jobs:
 
       php: 7.1
 
+      env: WITH_LOCKED=true
+
+    - <<: *TEST
+
+      php: 7.1
+
       env: WITH_HIGHEST=true
 
     - <<: *TEST


### PR DESCRIPTION
This PR

* [x] also runs a build with locked dependencies on PHP 7.1

Follows #18.

### Before

See https://travis-ci.org/Jan0707/phpstan-prophecy/builds/436194468:

<img width="1008" alt="screen shot 2018-10-26 at 17 34 42" src="https://user-images.githubusercontent.com/605483/47576714-798c2a80-d945-11e8-9da6-0956a1b92e21.png">

### After

See https://travis-ci.org/Jan0707/phpstan-prophecy/builds/446749712:

<img width="1006" alt="screen shot 2018-10-26 at 17 36 05" src="https://user-images.githubusercontent.com/605483/47576790-a4767e80-d945-11e8-96f1-bab94135c418.png">
