### PR TITLE
Fix PHP version to be used in CI with locked deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
 
     - <<: *TEST
 
-      php: 7.2
+      php: 7.1
 
       env: WITH_LOCKED=true
 


### PR DESCRIPTION
As found out in #27, IMHO we should fix the situation in this way.