### PR TITLE
Fix: Travis CI badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-![](https://api.travis-ci.org/Jan0707/phpstan-prophecy.svg?branch=master)
+[![Build Status](https://travis-ci.org/Jan0707/phpstan-prophecy.svg?branch=master)](https://travis-ci.org/Jan0707/phpstan-prophecy)
 
 # PHPStan-Prophecy
 


### PR DESCRIPTION
This PR

* [x] fixes the URL for the Travis CI build status badge