### PR TITLE
Fixed restoration of ObjectProphecyType from cache

### DIFF
--- a/src/Type/ObjectProphecyType.php
+++ b/src/Type/ObjectProphecyType.php
@@ -31,4 +31,13 @@ class ObjectProphecyType extends ObjectType
     {
         return $this->prophesizedClass;
     }
+
+    /**
+     * @param mixed[] $properties
+     * @return self
+     */
+    public static function __set_state(array $properties): Type
+    {
+        return new self($properties['prophesizedClass']);
+    }
 }


### PR DESCRIPTION
cc @lcobucci @rdohms

I finally figured out what didn't work about the cache! It was using this method from a parent where `new self()` was used 🤦‍♂️ 