### PR TITLE
Add missing import to avoid fatal error with php 7.3

### DIFF
--- a/src/Type/ObjectProphecyType.php
+++ b/src/Type/ObjectProphecyType.php
@@ -3,6 +3,7 @@
 namespace JanGregor\Prophecy\Type;
 
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 
 class ObjectProphecyType extends ObjectType


### PR DESCRIPTION
It fails with php 7.3, due to a missing import of PHPStan\Type\Type:

```
vendor/bin/phpstan analyze  -l 6
Note: Using configuration file /Users/swentz/git/mapper/phpstan.neon.
 18/33 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░]  54%
Fatal error: Declaration of JanGregor\Prophecy\Type\ObjectProphecyType::__set_state(array $properties): JanGregor\Prophecy\Type\Type must be compatible with PHPStan\Type\ObjectType::__set_state(array $properties): PHPStan\Type\Type in /Users/swentz/git/mapper/vendor/jangregor/phpstan-prophecy/src/Type/ObjectProphecyType.php on line 43
```