### PR TITLE
Fix return type of __set_state function

### DIFF
--- a/src/PhpDoc/TypeNodeResolverExtension.php
+++ b/src/PhpDoc/TypeNodeResolverExtension.php
@@ -57,5 +57,4 @@ class TypeNodeResolverExtension implements \PHPStan\PhpDoc\TypeNodeResolverExten
 
         return null;
     }
-
 }

--- a/src/Type/ObjectProphecyType.php
+++ b/src/Type/ObjectProphecyType.php
@@ -4,6 +4,7 @@ namespace JanGregor\Prophecy\Type;
 
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
+use PHPStan\Type\Type;
 
 class ObjectProphecyType extends ObjectType
 {


### PR DESCRIPTION
Getting the following error:

>  130/139 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░]  93% 3 secs/3 secs 60.0 MiBPHP Fatal error:  Declaration of JanGregor\Prophecy\Type\ObjectProphecyType::__set_state(array $properties): JanGregor\Prophecy\Type\Type must be compatible with PHPStan\Type\Type::__set_state(array $properties): PHPStan\Type\Type in /Users/alex/Documents/Sulu/myproject.localhost/vendor/jangregor/phpstan-prophecy/src/Type/ObjectProphecyType.php on line 43