### PR TITLE
set package type to "phpstan-extension"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "jangregor/phpstan-prophecy",
+    "type": "phpstan-extension",
     "description": "Provides a phpstan/phpstan extension for phpspec/prophecy",
     "license": "MIT",
     "authors": [
@@ -24,6 +25,13 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "phpstan": {
+            "includes": [
+                "src/extension.neon"
+            ]
+        }
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "539d7da45265239f695da54f2bfa79d5",
+    "content-hash": "e56688d7c779ee69ad341e9446626de0",
     "packages": [
         {
             "name": "composer/xdebug-handler",


### PR DESCRIPTION
So that this extension can be managed through the brand new `extension-installer` from phpstan