### PR TITLE
Fix: Require at least phpstan/phpstan:^0.12.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -58,6 +58,15 @@ jobs:
         php-version:
           - 7.4
 
+        phpstan-version:
+          - "^0.10.0"
+          - "^0.11.0"
+          - "^0.12.0"
+
+        dependencies:
+          - lowest
+          - highest
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2.0.0
@@ -73,12 +82,20 @@ jobs:
         uses: actions/cache@v1.0.3
         with:
           path: ~/.composer/cache
-          key: php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('**/composer.lock') }}
+          key: php-${{ matrix.php-version }}-phpstan-${{ matrix.phpstan-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            php-${{ matrix.php-version }}-composer-locked-
+            php-${{ matrix.php-version }}-phpstan-${{ matrix.phpstan-version }}-composer-${{ matrix.dependencies }}-
 
-      - name: "Install locked dependencies with composer"
-        run: composer install --no-interaction --no-progress --no-suggest
+      - name: "Require phpstan/phpstan:${{ matrix.phpstan-version }} with lowest dependencies"
+        if: matrix.dependencies == 'lowest'
+        run: composer require phpstan/phpstan:${{ matrix.phpstan-version }} --no-interaction --no-progress --no-suggest --prefer-lowest --update-with-dependencies
+
+      - name: "Require phpstan/phpstan:${{ matrix.phpstan-version }} with highest dependencies"
+        if: matrix.dependencies == 'highest'
+        run: composer require phpstan/phpstan:${{ matrix.phpstan-version }} --no-interaction --no-progress --no-suggest --update-with-dependencies
+
+      - name: "Run composer show phpstan/phpstan"
+        run: composer show phpstan/phpstan
 
       - name: "Run phpstan/phpstan"
         run: vendor/bin/phpstan analyse --configuration=phpstan.neon
@@ -91,15 +108,10 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.1
-          - 7.2
-          - 7.3
           - 7.4
 
         dependencies:
-          - lowest
           - locked
-          - highest
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -58,13 +58,9 @@ jobs:
         php-version:
           - 7.4
 
-        phpstan-version:
-          - "^0.10.0"
-          - "^0.11.0"
-          - "^0.12.0"
-
         dependencies:
           - lowest
+          - locked
           - highest
 
     steps:
@@ -82,20 +78,21 @@ jobs:
         uses: actions/cache@v1.0.3
         with:
           path: ~/.composer/cache
-          key: php-${{ matrix.php-version }}-phpstan-${{ matrix.phpstan-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
+          key: php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            php-${{ matrix.php-version }}-phpstan-${{ matrix.phpstan-version }}-composer-${{ matrix.dependencies }}-
+            php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-
 
-      - name: "Require phpstan/phpstan:${{ matrix.phpstan-version }} with lowest dependencies"
+      - name: "Install lowest dependencies with composer"
         if: matrix.dependencies == 'lowest'
-        run: composer require phpstan/phpstan:${{ matrix.phpstan-version }} --no-interaction --no-progress --no-suggest --prefer-lowest --update-with-dependencies
+        run: composer update --no-interaction --no-progress --no-suggest --prefer-lowest
 
-      - name: "Require phpstan/phpstan:${{ matrix.phpstan-version }} with highest dependencies"
+      - name: "Install locked dependencies with composer"
+        if: matrix.dependencies == 'locked'
+        run: composer install --no-interaction --no-progress --no-suggest
+
+      - name: "Install highest dependencies with composer"
         if: matrix.dependencies == 'highest'
-        run: composer require phpstan/phpstan:${{ matrix.phpstan-version }} --no-interaction --no-progress --no-suggest --update-with-dependencies
-
-      - name: "Run composer show phpstan/phpstan"
-        run: composer show phpstan/phpstan
+        run: composer update --no-interaction --no-progress --no-suggest
 
       - name: "Run phpstan/phpstan"
         run: vendor/bin/phpstan analyse --configuration=phpstan.neon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.5.0...master`][0.5.0...master].
+For a full diff see [`0.5.1...master`][0.5.1...master].
+
+## [`0.5.1`][0.5.1]
+
+For a full diff see [`0.5.0...0.5.1`][0.5.0...0.5.1].
+
+### Changed
+
+* Required at least `phpstan/phpstan:^0.12.0` ([#79]), by [@localheinz]
 
 ## [`0.5.0`][0.5.0]
 
@@ -57,6 +65,7 @@ For a full diff see [`afd6fd9...0.1`][afd6fd9...0.1].
 [0.4.1]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.4.1
 [0.4.2]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.4.2
 [0.5.0]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.5.0
+[0.5.1]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.5.1
 
 [afd6fd9...0.1]: https://github.com/Jan0707/phpstan-prophecy/compare/afd6fd9...0.1
 [0.1...0.1.1]: https://github.com/Jan0707/phpstan-prophecy/compare/0.1...0.1.1
@@ -67,9 +76,11 @@ For a full diff see [`afd6fd9...0.1`][afd6fd9...0.1].
 [0.4...0.4.1]: https://github.com/Jan0707/phpstan-prophecy/compare/0.4...0.4.1
 [0.4.1...0.4.2]: https://github.com/Jan0707/phpstan-prophecy/compare/0.4.1...0.4.2
 [0.4.2...0.5.0]: https://github.com/Jan0707/phpstan-prophecy/compare/0.4.2...0.5.0
-[0.5.0...master]: https://github.com/Jan0707/phpstan-prophecy/compare/0.5.0...master
+[0.5.0...0.5.1]: https://github.com/Jan0707/phpstan-prophecy/compare/0.5.0...0.5.1
+[0.5.1...master]: https://github.com/Jan0707/phpstan-prophecy/compare/0.5.1...master
 
 [#67]: https://github.com/Jan0707/phpstan-prophecy/pull/67
+[#79]: https://github.com/Jan0707/phpstan-prophecy/pull/79
 
 [@localheinz]: https://github.com/localheinz
 [@PedroTroller]: https://github.com/PedroTroller

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "phpstan/phpstan": "^0.10.0 || ^0.11.0 || ^0.12.2"
+        "phpstan/phpstan": "^0.12.0"
     },
     "conflict": {
         "phpspec/prophecy": "<1.7,>=2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97c478fb5ea142f9c35e2c0e8c6e2dbd",
+    "content-hash": "89d1d4b13b8dc1293b6ae500b26a67b3",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -813,6 +813,7 @@
                 "json",
                 "printer"
             ],
+            "abandoned": "ergebnis/json-printer",
             "time": "2018-08-11T23:54:50+00:00"
         },
         {


### PR DESCRIPTION
This PR

* [x] runs static analysis using different versions of `phpstan/phpstan`
* [x] requires at least `phpstan/phpstan:0.12.0`

💁‍♂ A closer look at the tests reveal that the tests aren't important - they are only fixtures for running a static analysis using `phpstan`.