### PR TITLE
Enhancement: Move indirect tests into separate namespace

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,8 +13,8 @@
     failOnWarning="true"
 >
     <testsuites>
-        <testsuite name="Base">
-            <directory>tests/Test</directory>
+        <testsuite name="Static Analysis">
+            <directory>tests/StaticAnalysis</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/StaticAnalysis/Bar.php
+++ b/tests/StaticAnalysis/Bar.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JanGregor\Prophecy\Test\Model;
+namespace JanGregor\Prophecy\Test\StaticAnalysis;
 
 interface Bar
 {

--- a/tests/StaticAnalysis/BaseModel.php
+++ b/tests/StaticAnalysis/BaseModel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace JanGregor\Prophecy\Test\Model;
+namespace JanGregor\Prophecy\Test\StaticAnalysis;
 
 class BaseModel
 {

--- a/tests/StaticAnalysis/BaseModelTest.php
+++ b/tests/StaticAnalysis/BaseModelTest.php
@@ -1,11 +1,7 @@
 <?php
 
-namespace JanGregor\Prophecy\Test\Test;
+namespace JanGregor\Prophecy\Test\StaticAnalysis;
 
-use JanGregor\Prophecy\Test\Model\Bar;
-use JanGregor\Prophecy\Test\Model\BaseModel;
-use JanGregor\Prophecy\Test\Model\Baz;
-use JanGregor\Prophecy\Test\Model\Foo;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -13,7 +9,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 /**
  * @internal
  *
- * @covers \JanGregor\Prophecy\Test\Model\BaseModel
+ * @coversNothing
  */
 final class BaseModelTest extends TestCase
 {

--- a/tests/StaticAnalysis/Baz.php
+++ b/tests/StaticAnalysis/Baz.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JanGregor\Prophecy\Test\Model;
+namespace JanGregor\Prophecy\Test\StaticAnalysis;
 
 abstract class Baz
 {

--- a/tests/StaticAnalysis/Foo.php
+++ b/tests/StaticAnalysis/Foo.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JanGregor\Prophecy\Test\Model;
+namespace JanGregor\Prophecy\Test\StaticAnalysis;
 
 interface Foo
 {


### PR DESCRIPTION
This PR

* [x] moves files related to _indirectly_ testing production code via static analysis into a dedicated namespace