### PR TITLE
Enhancement: Use ergebnis/license

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,18 +11,19 @@ declare(strict_types=1);
  * @see https://github.com/Jan0707/phpstan-prophecy
  */
 
+use Ergebnis\License;
 use Ergebnis\PhpCsFixer\Config;
 
-$header = <<<'EOF'
-Copyright (c) 2018 Jan Gregor Emge-Triebel
+$license = License\Type\MIT::text(
+    __DIR__ . '/LICENSE',
+    License\Year::fromString('2018'),
+    License\Holder::fromString('Jan Gregor Emge-Triebel'),
+    License\Url::fromString('https://github.com/Jan0707/phpstan-prophecy')
+);
 
-For the full copyright and license information, please view
-the LICENSE file that was distributed with this source code.
+$license->save();
 
-@see https://github.com/Jan0707/phpstan-prophecy
-EOF;
-
-$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header), [
+$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($license->header()), [
     'final_class' => false,
 ]);
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,16 @@
-MIT License
+The MIT License (MIT)
 
 Copyright (c) 2018 Jan Gregor Emge-Triebel
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.1.1",
+        "ergebnis/license": "~0.1.0",
         "ergebnis/php-cs-fixer-config": "~1.1.2",
         "phpspec/prophecy": "^1.7",
         "phpunit/phpunit": "^6.0 || ^7.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33f340c56b308272d29e4222bd984077",
+    "content-hash": "b00330616dc81295d47077ad31246742",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -518,6 +518,64 @@
                 "printer"
             ],
             "time": "2019-12-19T14:42:54+00:00"
+        },
+        {
+            "name": "ergebnis/license",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/license.git",
+                "reference": "ca94bcaabcbd56e663899fc4510e9cfdd8c6329c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/license/zipball/ca94bcaabcbd56e663899fc4510e9cfdd8c6329c",
+                "reference": "ca94bcaabcbd56e663899fc4510e9cfdd8c6329c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.2.2",
+                "ergebnis/php-cs-fixer-config": "~1.1.3",
+                "ergebnis/phpstan-rules": "~0.14.2",
+                "ergebnis/test-util": "~0.9.1",
+                "infection/infection": "~0.13.6",
+                "jangregor/phpstan-prophecy": "~0.6.0",
+                "phpstan/extension-installer": "^1.0.3",
+                "phpstan/phpstan": "~0.12.5",
+                "phpstan/phpstan-deprecation-rules": "~0.12.2",
+                "phpstan/phpstan-phpunit": "~0.12.6",
+                "phpstan/phpstan-strict-rules": "~0.12.1",
+                "phpunit/phpunit": "^7.5.20",
+                "psalm/plugin-phpunit": "~0.8.1",
+                "symfony/filesystem": "^4.4.0",
+                "vimeo/psalm": "^3.8.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\License\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides an abstraction for a license.",
+            "homepage": "https://github.com/ergebnis/license",
+            "keywords": [
+                "license"
+            ],
+            "time": "2020-01-19T13:40:34+00:00"
         },
         {
             "name": "ergebnis/php-cs-fixer-config",


### PR DESCRIPTION
This PR

* [x] requires and uses `ergebnis/license` to generate a file-level license header and emit a license file