### PR TITLE
Fix: Mark classes as final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.6.0...master`][0.6.0...master].
+For a full diff see [`0.6.1...master`][0.6.1...master].
+
+## [`0.6.1`][0.6.1]
+
+For a full diff see [`0.6.0...0.6.1`][0.6.0...0.6.1].
+
+### Changed
+
+* Marked classes as `final` ([#118]), by [@localheinz]
 
 ## [`0.6.0`][0.6.0]
 
@@ -76,6 +84,7 @@ For a full diff see [`afd6fd9...0.1`][afd6fd9...0.1].
 [0.5.0]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.5.0
 [0.5.1]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.5.1
 [0.6.0]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.6.0
+[0.6.1]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.6.1
 
 [afd6fd9...0.1]: https://github.com/Jan0707/phpstan-prophecy/compare/afd6fd9...0.1
 [0.1...0.1.1]: https://github.com/Jan0707/phpstan-prophecy/compare/0.1...0.1.1
@@ -88,12 +97,14 @@ For a full diff see [`afd6fd9...0.1`][afd6fd9...0.1].
 [0.4.2...0.5.0]: https://github.com/Jan0707/phpstan-prophecy/compare/0.4.2...0.5.0
 [0.5.0...0.5.1]: https://github.com/Jan0707/phpstan-prophecy/compare/0.5.0...0.5.1
 [0.5.1...0.6.0]: https://github.com/Jan0707/phpstan-prophecy/compare/0.5.1...0.6.0
-[0.6.0...master]: https://github.com/Jan0707/phpstan-prophecy/compare/0.6.0...master
+[0.6.0...0.6.1]: https://github.com/Jan0707/phpstan-prophecy/compare/0.6.0...0.6.0
+[0.6.1...master]: https://github.com/Jan0707/phpstan-prophecy/compare/0.6.1...master
 
 [#67]: https://github.com/Jan0707/phpstan-prophecy/pull/67
 [#79]: https://github.com/Jan0707/phpstan-prophecy/pull/79
 [#92]: https://github.com/Jan0707/phpstan-prophecy/pull/92
 [#94]: https://github.com/Jan0707/phpstan-prophecy/pull/94
+[#118]: https://github.com/Jan0707/phpstan-prophecy/pull/118
 
 [@localheinz]: https://github.com/localheinz
 [@PedroTroller]: https://github.com/PedroTroller

--- a/src/Extension/ObjectProphecyRevealDynamicReturnTypeExtension.php
+++ b/src/Extension/ObjectProphecyRevealDynamicReturnTypeExtension.php
@@ -19,7 +19,7 @@ use PHPStan\Analyser;
 use PHPStan\Reflection;
 use PHPStan\Type;
 
-class ObjectProphecyRevealDynamicReturnTypeExtension implements Type\DynamicMethodReturnTypeExtension
+final class ObjectProphecyRevealDynamicReturnTypeExtension implements Type\DynamicMethodReturnTypeExtension
 {
     public function getClass(): string
     {

--- a/src/Extension/ObjectProphecyWillExtendOrImplementDynamicReturnTypeExtension.php
+++ b/src/Extension/ObjectProphecyWillExtendOrImplementDynamicReturnTypeExtension.php
@@ -20,7 +20,7 @@ use PHPStan\Reflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type;
 
-class ObjectProphecyWillExtendOrImplementDynamicReturnTypeExtension implements Type\DynamicMethodReturnTypeExtension
+final class ObjectProphecyWillExtendOrImplementDynamicReturnTypeExtension implements Type\DynamicMethodReturnTypeExtension
 {
     public function getClass(): string
     {

--- a/src/Extension/ProphetProphesizeDynamicReturnTypeExtension.php
+++ b/src/Extension/ProphetProphesizeDynamicReturnTypeExtension.php
@@ -20,7 +20,7 @@ use PHPStan\Reflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type;
 
-class ProphetProphesizeDynamicReturnTypeExtension implements Type\DynamicMethodReturnTypeExtension
+final class ProphetProphesizeDynamicReturnTypeExtension implements Type\DynamicMethodReturnTypeExtension
 {
     private $className;
 

--- a/src/PhpDoc/TypeNodeResolverExtension.php
+++ b/src/PhpDoc/TypeNodeResolverExtension.php
@@ -20,7 +20,7 @@ use PHPStan\PhpDocParser;
 use PHPStan\Type;
 use Prophecy\Prophecy\ObjectProphecy;
 
-class TypeNodeResolverExtension implements PhpDoc\TypeNodeResolverAwareExtension, PhpDoc\TypeNodeResolverExtension
+final class TypeNodeResolverExtension implements PhpDoc\TypeNodeResolverAwareExtension, PhpDoc\TypeNodeResolverExtension
 {
     /**
      * @var PhpDoc\TypeNodeResolver

--- a/src/Reflection/ObjectProphecyMethodReflection.php
+++ b/src/Reflection/ObjectProphecyMethodReflection.php
@@ -18,7 +18,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type;
 use Prophecy\Prophecy;
 
-class ObjectProphecyMethodReflection implements Reflection\MethodReflection
+final class ObjectProphecyMethodReflection implements Reflection\MethodReflection
 {
     private $declaringClass;
 

--- a/src/Reflection/ProphecyMethodsClassReflectionExtension.php
+++ b/src/Reflection/ProphecyMethodsClassReflectionExtension.php
@@ -15,7 +15,7 @@ namespace JanGregor\Prophecy\Reflection;
 
 use PHPStan\Reflection;
 
-class ProphecyMethodsClassReflectionExtension implements Reflection\MethodsClassReflectionExtension
+final class ProphecyMethodsClassReflectionExtension implements Reflection\MethodsClassReflectionExtension
 {
     public function hasMethod(Reflection\ClassReflection $classReflection, string $methodName): bool
     {

--- a/src/Type/ObjectProphecyType.php
+++ b/src/Type/ObjectProphecyType.php
@@ -15,12 +15,12 @@ namespace JanGregor\Prophecy\Type;
 
 use PHPStan\Type;
 
-class ObjectProphecyType extends Type\ObjectType
+final class ObjectProphecyType extends Type\ObjectType
 {
     /**
      * @var string[]
      */
-    protected $prophesizedClasses;
+    private $prophesizedClasses;
 
     public function __construct(string ...$prophesizedClasses)
     {


### PR DESCRIPTION
This PR

* [x] marks classes as `final`

💁‍♂ There's probably no reason to extend these classes.