### PR TITLE
Fix: Method invocations on methods of ObjectProphecy might have side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`0.6.0...0.6.1`][0.6.0...0.6.1].
 ### Changed
 
 * Marked classes as `final` ([#118]), by [@localheinz]
+* Modified return value of `ObjectPropecyMethodReflection::hasSideEffects()` as invoking methods on an instance of `Prophecy\Prophecy\ObjectProphecy` might have side effects ([#119]), by [@localheinz]
 
 ## [`0.6.0`][0.6.0]
 
@@ -105,6 +106,7 @@ For a full diff see [`afd6fd9...0.1`][afd6fd9...0.1].
 [#92]: https://github.com/Jan0707/phpstan-prophecy/pull/92
 [#94]: https://github.com/Jan0707/phpstan-prophecy/pull/94
 [#118]: https://github.com/Jan0707/phpstan-prophecy/pull/118
+[#119]: https://github.com/Jan0707/phpstan-prophecy/pull/119
 
 [@localheinz]: https://github.com/localheinz
 [@PedroTroller]: https://github.com/PedroTroller

--- a/src/Reflection/ObjectProphecyMethodReflection.php
+++ b/src/Reflection/ObjectProphecyMethodReflection.php
@@ -100,7 +100,7 @@ final class ObjectProphecyMethodReflection implements Reflection\MethodReflectio
 
     public function hasSideEffects(): TrinaryLogic
     {
-        return TrinaryLogic::createNo();
+        return TrinaryLogic::createMaybe();
     }
 
     public function getDocComment(): ?string

--- a/tests/Unit/Reflection/ObjectProphecyMethodReflectionTest.php
+++ b/tests/Unit/Reflection/ObjectProphecyMethodReflectionTest.php
@@ -64,7 +64,7 @@ final class ObjectProphecyMethodReflectionTest extends Framework\TestCase
         ];
 
         self::assertEquals($variants, $reflection->getVariants());
-        self::assertTrue($reflection->hasSideEffects()->equals(TrinaryLogic::createNo()));
+        self::assertTrue($reflection->hasSideEffects()->equals(TrinaryLogic::createMaybe()));
         self::assertTrue($reflection->isDeprecated()->equals(TrinaryLogic::createNo()));
         self::assertTrue($reflection->isInternal()->equals(TrinaryLogic::createNo()));
         self::assertFalse($reflection->isPrivate());


### PR DESCRIPTION
This PR

* [x] modifies the return value of `ObjectPropecyMethodReflection::hasSideEffects()` as invoking methods on an instance of `Prophecy\Prophecy\ObjectProphecy` might have side effects

Fixes #112.

💁‍♂ Does that make sense, @func0der?