### PR TITLE
Fix: Allow installation with phpunit/phpunit:^9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.6.1...master`][0.6.1...master].
+For a full diff see [`0.6.2...master`][0.6.2...master].
+
+## [`0.6.2`][0.6.2]
+
+For a full diff see [`0.6.1...0.6.2`][0.6.1...0.6.2].
+
+### Fixed
+
+* Allowed installation with `phpunit/phpunit:^9` ([#124]), by [@localheinz]
 
 ## [`0.6.1`][0.6.1]
 
@@ -86,6 +94,7 @@ For a full diff see [`afd6fd9...0.1`][afd6fd9...0.1].
 [0.5.1]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.5.1
 [0.6.0]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.6.0
 [0.6.1]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.6.1
+[0.6.2]: https://github.com/Jan0707/phpstan-prophecy/releases/tag/0.6.2
 
 [afd6fd9...0.1]: https://github.com/Jan0707/phpstan-prophecy/compare/afd6fd9...0.1
 [0.1...0.1.1]: https://github.com/Jan0707/phpstan-prophecy/compare/0.1...0.1.1
@@ -98,8 +107,9 @@ For a full diff see [`afd6fd9...0.1`][afd6fd9...0.1].
 [0.4.2...0.5.0]: https://github.com/Jan0707/phpstan-prophecy/compare/0.4.2...0.5.0
 [0.5.0...0.5.1]: https://github.com/Jan0707/phpstan-prophecy/compare/0.5.0...0.5.1
 [0.5.1...0.6.0]: https://github.com/Jan0707/phpstan-prophecy/compare/0.5.1...0.6.0
-[0.6.0...0.6.1]: https://github.com/Jan0707/phpstan-prophecy/compare/0.6.0...0.6.0
-[0.6.1...master]: https://github.com/Jan0707/phpstan-prophecy/compare/0.6.1...master
+[0.6.0...0.6.1]: https://github.com/Jan0707/phpstan-prophecy/compare/0.6.0...0.6.1
+[0.6.1...0.6.2]: https://github.com/Jan0707/phpstan-prophecy/compare/0.6.1...0.6.2
+[0.6.2...master]: https://github.com/Jan0707/phpstan-prophecy/compare/0.6.2...master
 
 [#67]: https://github.com/Jan0707/phpstan-prophecy/pull/67
 [#79]: https://github.com/Jan0707/phpstan-prophecy/pull/79
@@ -107,6 +117,7 @@ For a full diff see [`afd6fd9...0.1`][afd6fd9...0.1].
 [#94]: https://github.com/Jan0707/phpstan-prophecy/pull/94
 [#118]: https://github.com/Jan0707/phpstan-prophecy/pull/118
 [#119]: https://github.com/Jan0707/phpstan-prophecy/pull/119
+[#124]: https://github.com/Jan0707/phpstan-prophecy/pull/124
 
 [@localheinz]: https://github.com/localheinz
 [@PedroTroller]: https://github.com/PedroTroller

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "conflict": {
         "phpspec/prophecy": "<1.7,>=2.0",
-        "phpunit/phpunit": "<6.0,>=9.0"
+        "phpunit/phpunit": "<6.0,>=10.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b00330616dc81295d47077ad31246742",
+    "content-hash": "33829ffb58023ba1137fb012f98dd4ce",
     "packages": [
         {
             "name": "phpstan/phpstan",


### PR DESCRIPTION
This PR

* [x] allows installation with `phpunit/phpunit:^9`