### PR TITLE
Fix: Move classes used in static analysis into different namespaces

### DIFF
--- a/tests/StaticAnalysis/Src/Bar.php
+++ b/tests/StaticAnalysis/Src/Bar.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * @see https://github.com/Jan0707/phpstan-prophecy
  */
 
-namespace JanGregor\Prophecy\Test\StaticAnalysis;
+namespace JanGregor\Prophecy\Test\StaticAnalysis\Src;
 
-interface Foo
+interface Bar
 {
-    public function foo(): string;
+    public function bar(): string;
 }

--- a/tests/StaticAnalysis/Src/BaseModel.php
+++ b/tests/StaticAnalysis/Src/BaseModel.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/Jan0707/phpstan-prophecy
  */
 
-namespace JanGregor\Prophecy\Test\StaticAnalysis;
+namespace JanGregor\Prophecy\Test\StaticAnalysis\Src;
 
 class BaseModel
 {

--- a/tests/StaticAnalysis/Src/Baz.php
+++ b/tests/StaticAnalysis/Src/Baz.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * @see https://github.com/Jan0707/phpstan-prophecy
  */
 
-namespace JanGregor\Prophecy\Test\StaticAnalysis;
+namespace JanGregor\Prophecy\Test\StaticAnalysis\Src;
 
-interface Bar
+abstract class Baz
 {
-    public function bar(): string;
+    abstract public function baz(): string;
 }

--- a/tests/StaticAnalysis/Src/Foo.php
+++ b/tests/StaticAnalysis/Src/Foo.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * @see https://github.com/Jan0707/phpstan-prophecy
  */
 
-namespace JanGregor\Prophecy\Test\StaticAnalysis;
+namespace JanGregor\Prophecy\Test\StaticAnalysis\Src;
 
-abstract class Baz
+interface Foo
 {
-    abstract public function baz(): string;
+    public function foo(): string;
 }

--- a/tests/StaticAnalysis/Test/BaseModelTest.php
+++ b/tests/StaticAnalysis/Test/BaseModelTest.php
@@ -11,8 +11,12 @@ declare(strict_types=1);
  * @see https://github.com/Jan0707/phpstan-prophecy
  */
 
-namespace JanGregor\Prophecy\Test\StaticAnalysis;
+namespace JanGregor\Prophecy\Test\StaticAnalysis\Test;
 
+use JanGregor\Prophecy\Test\StaticAnalysis\Src\Bar;
+use JanGregor\Prophecy\Test\StaticAnalysis\Src\BaseModel;
+use JanGregor\Prophecy\Test\StaticAnalysis\Src\Baz;
+use JanGregor\Prophecy\Test\StaticAnalysis\Src\Foo;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -25,7 +29,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 final class BaseModelTest extends TestCase
 {
     /**
-     * @var BaseModel|ObjectProphecy
+     * @var \JanGregor\Prophecy\Test\StaticAnalysis\Src\BaseModel|ObjectProphecy
      */
     private $subject;
 


### PR DESCRIPTION
This PR

* [x] moves classes used in static analysis into different namespaces