### PR TITLE
Enhancement: Use Makefile instead of composer scripts

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We are using [`friendsofphp/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-C
 Run
 
 ```
-$ composer cs
+$ make coding-standards
 ```
 
 to automatically fix coding standard violations.
@@ -23,7 +23,7 @@ We are using [`phpstan/phpstan`](https://github.com/phpstan/phpstan) to statical
 Run
 
 ```
-$ composer stan
+$ make static-code-analysis
 ```
 
 to run a static code analysis.
@@ -35,7 +35,7 @@ We are using [`phpunit/phpunit`](https://github.com/sebastianbergmann/phpunit) t
 Run
 
 ```
-$ composer test
+$ make tests
 ```
 
 to run all the tests.
@@ -45,7 +45,7 @@ to run all the tests.
 Run
 
 ```
-$ composer build
+$ make
 ```
 
 to enforce coding standards, perform a static code analysis, and run tests!

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: it
+it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets
+
+.PHONY: coding-standards
+coding-standards: vendor ## Fixes code style issues with friendsofphp/php-cs-fixer
+	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose
+
+.PHONY: help
+help: ## Displays this list of targets with descriptions
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: static-code-analysis
+static-code-analysis: vendor ## Runs a static code analysis with phpstan/phpstan
+	vendor/bin/phpstan analyse --configuration=phpstan.neon
+
+.PHONY: tests
+tests: vendor ## Runs tests with phpunit/phpunit
+	vendor/bin/phpunit --configuration=phpunit.xml
+
+vendor: composer.json composer.lock
+	composer validate --strict
+	composer install --no-interaction --no-progress --no-suggest
+	composer normalize

--- a/composer.json
+++ b/composer.json
@@ -48,17 +48,5 @@
         "psr-4": {
             "JanGregor\\Prophecy\\Test\\": "tests/"
         }
-    },
-    "scripts": {
-        "build": [
-            "@composer validate",
-            "@composer normalize",
-            "@cs",
-            "@stan",
-            "@test"
-        ],
-        "cs": "php-cs-fixer fix --diff --verbose",
-        "stan": "phpstan analyse",
-        "test": "phpunit"
     }
 }


### PR DESCRIPTION
This PR

* [x] uses a `Makefile` instead of `composer` scripts