### PR TITLE
Fix: Reference GitHub Actions instead of Travis CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # CONTRIBUTING
 
-We are using [Travis CI](https://travis-ci.com) as a continuous integration system.
+We are using [GitHub Actions](https://github.com/features/actions) as a continuous integration system.
 
-For details, see [`.travis.yml`](../.travis.yml).
+For details, see [`workflows/continuous-integration.yml`](workflows/continuous-integration.yml).
 
 ## Coding Standards
 


### PR DESCRIPTION
This PR

* [x] references GitHub Actions instead of Travis CI in `CONTRIBUTING.md`