### PR TITLE
Fix: Configure indentation for Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,9 @@ trim_trailing_whitespace = true
 [*.neon]
 indent_style = tab
 
+
 [*.yml]
 indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This PR

* [x] configures the indentation type for `Makefile` in `.editorconfig`

Follows #127.