### PR TITLE
Fix: Explicitly list ignored files and directories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,11 @@
-Tests               export-ignore
-vendor              export-ignore
-.*                  export-ignore
-phpstan.neon        export-ignore
-phpunit.xml         export-ignore
+.github/        export-ignore
+docker/         export-ignore
+tests/          export-ignore
+.editorconfig   export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+.php_cs         export-ignore
+composer.lock   export-ignore
+Makefile        export-ignore
+phpstan.neon    export-ignore
+phpunit.xml     export-ignore


### PR DESCRIPTION
This PR

* [x] explicitly lists files and directories that should not be exported