### PR TITLE
Fix: Split test cases used in static code analysis

### DIFF
--- a/test/StaticAnalysis/Src/BaseModel.php
+++ b/test/StaticAnalysis/Src/BaseModel.php
@@ -16,32 +16,21 @@ namespace JanGregor\Prophecy\Test\StaticAnalysis\Src;
 class BaseModel
 {
     /**
-     * @var string
+     * @var null|string
      */
     private $foo;
 
-    /**
-     * @return string
-     */
-    public function getFoo(): string
+    public function getFoo(): ?string
     {
         return $this->foo;
     }
 
-    /**
-     * @param string $foo
-     */
     public function setFoo(string $foo): void
     {
         $this->foo = $foo;
     }
 
-    /**
-     * @param int $number
-     *
-     * @return int
-     */
-    public function doubleTheNumber(int $number)
+    public function doubleTheNumber(int $number): int
     {
         return 2 * $number;
     }

--- a/test/StaticAnalysis/Test/BaseModelTest.php
+++ b/test/StaticAnalysis/Test/BaseModelTest.php
@@ -13,94 +13,70 @@ declare(strict_types=1);
 
 namespace JanGregor\Prophecy\Test\StaticAnalysis\Test;
 
-use JanGregor\Prophecy\Test\StaticAnalysis\Src\Bar;
-use JanGregor\Prophecy\Test\StaticAnalysis\Src\BaseModel;
-use JanGregor\Prophecy\Test\StaticAnalysis\Src\Baz;
-use JanGregor\Prophecy\Test\StaticAnalysis\Src\Foo;
-use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\Prophecy\ObjectProphecy;
+use JanGregor\Prophecy\Test\StaticAnalysis\Src;
+use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @coversNothing
+ * @covers \JanGregor\Prophecy\Test\StaticAnalysis\Src\BaseModel
  */
-final class BaseModelTest extends TestCase
+final class BaseModelTest extends Framework\TestCase
 {
-    /**
-     * @var \JanGregor\Prophecy\Test\StaticAnalysis\Src\BaseModel|ObjectProphecy
-     */
-    private $subject;
-
-    public function testBasicProperty(): void
+    public function testDefaults(): void
     {
-        $word = 'bar';
+        $model = new Src\BaseModel();
 
-        $subject = new BaseModel();
-        $subject->setFoo($word);
-
-        self::assertEquals($word, $subject->getFoo());
-        self::assertEquals(4, $subject->doubleTheNumber(2));
+        self::assertNull($model->getFoo());
     }
 
-    public function testWithProphecy(): void
+    public function testCanSetAndGetFoo(): void
     {
-        $subject = $this->prophesize(BaseModel::class);
-        $subject->getFoo()->willReturn('bar');
+        $foo = 'Hello!';
 
-        $subject->doubleTheNumber(Argument::is(2))->willReturn(5);
+        $model = new Src\BaseModel();
 
-        self::assertEquals('bar', $subject->reveal()->getFoo());
-        self::assertEquals(5, $subject->reveal()->doubleTheNumber(2));
+        $model->setFoo($foo);
+
+        self::assertSame($foo, $model->getFoo());
     }
 
-    /**
-     * @before
-     */
-    public function createSubject(): void
+    public function testCanDoubleTheNumber(): void
     {
-        $this->subject = $this->prophesize(BaseModel::class);
+        $number = 9000;
+
+        $model = new Src\BaseModel();
+
+        self::assertSame(2 * $number, $model->doubleTheNumber($number));
     }
 
-    public function testProphesizedAttributesShouldAlsoWork(): void
+    public function testBarReturnsBar(): void
     {
-        $this->subject->getFoo()->willReturn('bar');
-        $this->subject->doubleTheNumber(Argument::is(2))->willReturn(5);
+        $value = 'Hmm';
 
-        $subject = $this->subject->reveal();
+        $bar = $this->prophesize(Src\Bar::class);
 
-        self::assertEquals('bar', $subject->getFoo());
-        self::assertEquals(5, $subject->doubleTheNumber(2));
+        $bar
+            ->bar()
+            ->willReturn($value);
+
+        $model = new Src\BaseModel();
+
+        self::assertSame($value, $model->bar($bar->reveal()));
     }
 
-    public function testWillExtendWorks(): void
+    public function testBazReturnsBaz(): void
     {
-        $baz = $this->prophesize()->willExtend(Baz::class);
+        $value = 'Ah!';
+
+        $baz = $this->prophesize(Src\Baz::class);
 
         $baz
             ->baz()
-            ->shouldBeCalled()
-            ->willReturn('Hmm');
+            ->willReturn($value);
 
-        $subject = new BaseModel();
+        $model = new Src\BaseModel();
 
-        self::assertSame('Hmm', $subject->baz($baz->reveal()));
-    }
-
-    public function testWillImplementWorks(): void
-    {
-        $fooThatAlsoBars = $this->prophesize(Foo::class);
-
-        $fooThatAlsoBars->willImplement(Bar::class);
-
-        $fooThatAlsoBars
-            ->bar()
-            ->shouldBeCalled()
-            ->willReturn('Oh');
-
-        $subject = new BaseModel();
-
-        self::assertSame('Oh', $subject->bar($fooThatAlsoBars->reveal()));
+        self::assertSame($value, $model->baz($baz->reveal()));
     }
 }

--- a/test/StaticAnalysis/Test/ProphesizeTest.php
+++ b/test/StaticAnalysis/Test/ProphesizeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Jan Gregor Emge-Triebel
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/Jan0707/phpstan-prophecy
+ */
+
+namespace JanGregor\Prophecy\Test\StaticAnalysis\Test;
+
+use JanGregor\Prophecy\Test\StaticAnalysis\Src;
+use PHPUnit\Framework;
+use Prophecy\Argument;
+use Prophecy\Prophecy;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class ProphesizeTest extends Framework\TestCase
+{
+    /**
+     * @var Prophecy\ObjectProphecy|Src\BaseModel
+     */
+    private $prophecy;
+
+    protected function setUp(): void
+    {
+        $this->prophecy = $this->prophesize(Src\BaseModel::class);
+    }
+
+    public function testInSetUp(): void
+    {
+        $this->prophecy
+            ->getFoo()
+            ->willReturn('bar');
+
+        $this->prophecy
+            ->doubleTheNumber(Argument::is(2))
+            ->willReturn(5);
+
+        $testDouble = $this->prophecy->reveal();
+
+        self::assertEquals('bar', $testDouble->getFoo());
+        self::assertEquals(5, $testDouble->doubleTheNumber(2));
+    }
+
+    public function testInTestMethod(): void
+    {
+        $prophecy = $this->prophesize(Src\BaseModel::class);
+
+        $prophecy
+            ->getFoo()
+            ->willReturn('bar');
+
+        $prophecy
+            ->doubleTheNumber(Argument::is(2))
+            ->willReturn(5);
+
+        $testDouble = $prophecy->reveal();
+
+        self::assertEquals('bar', $testDouble->getFoo());
+        self::assertEquals(5, $testDouble->doubleTheNumber(2));
+    }
+}

--- a/test/StaticAnalysis/Test/WillExtendTest.php
+++ b/test/StaticAnalysis/Test/WillExtendTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Jan Gregor Emge-Triebel
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/Jan0707/phpstan-prophecy
+ */
+
+namespace JanGregor\Prophecy\Test\StaticAnalysis\Test;
+
+use JanGregor\Prophecy\Test\StaticAnalysis\Src;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class WillExtendTest extends Framework\TestCase
+{
+    public function testInTestMethod(): void
+    {
+        $prophecy = $this->prophesize()->willExtend(Src\Baz::class);
+
+        $prophecy
+            ->baz()
+            ->shouldBeCalled()
+            ->willReturn('Hmm');
+
+        $subject = new Src\BaseModel();
+
+        self::assertSame('Hmm', $subject->baz($prophecy->reveal()));
+    }
+}

--- a/test/StaticAnalysis/Test/WillImplementTest.php
+++ b/test/StaticAnalysis/Test/WillImplementTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Jan Gregor Emge-Triebel
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/Jan0707/phpstan-prophecy
+ */
+
+namespace JanGregor\Prophecy\Test\StaticAnalysis\Test;
+
+use JanGregor\Prophecy\Test\StaticAnalysis\Src;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+final class WillImplementTest extends Framework\TestCase
+{
+    public function testInTestMethod(): void
+    {
+        $prophecy = $this->prophesize(Src\Foo::class)->willImplement(Src\Bar::class);
+
+        $prophecy
+            ->bar()
+            ->shouldBeCalled()
+            ->willReturn('Oh');
+
+        $subject = new Src\BaseModel();
+
+        self::assertSame('Oh', $subject->bar($prophecy->reveal()));
+    }
+}


### PR DESCRIPTION
This PR

* [x] splits test cases used in static code analysis

Related to #121.