### PR TITLE
Fix: Type should be resolved without DocBlock

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,8 @@ includes:
 	- src/extension.neon
 
 parameters:
+	ignoreErrors:
+		- '#^Property .* has no typehint specified\.$#'
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max
 	paths:

--- a/test/StaticAnalysis/Test/ProphesizeTest.php
+++ b/test/StaticAnalysis/Test/ProphesizeTest.php
@@ -16,7 +16,6 @@ namespace JanGregor\Prophecy\Test\StaticAnalysis\Test;
 use JanGregor\Prophecy\Test\StaticAnalysis\Src;
 use PHPUnit\Framework;
 use Prophecy\Argument;
-use Prophecy\Prophecy;
 
 /**
  * @internal
@@ -25,9 +24,6 @@ use Prophecy\Prophecy;
  */
 final class ProphesizeTest extends Framework\TestCase
 {
-    /**
-     * @var Prophecy\ObjectProphecy|Src\BaseModel
-     */
     private $prophecy;
 
     protected function setUp(): void


### PR DESCRIPTION
This PR

* [x] removes a DocBlock from a field

💁‍♂ The type should be resolved without a DocBlock.