### PR TITLE
Enhancement: Use .build directory for temporary files

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,6 +54,9 @@ jobs:
       - name: "Run ergebnis/composer-normalize"
         run: "composer normalize --dry-run"
 
+      - name: "Create cache directory for friendsofphp/php-cs-fixer"
+        run: "mkdir -p .build/php-cs-fixer"
+
       - name: "Run friendsofphp/php-cs-fixer"
         run: "vendor/bin/php-cs-fixer fix --diff --dry-run --verbose"
 
@@ -108,6 +111,9 @@ jobs:
 
       - name: "Show phpstan/phpstan version"
         run: "vendor/bin/phpstan --version"
+
+      - name: "Create cache directory for phpstan/phpstan"
+        run: "mkdir -p .build/phpstan"
 
       - name: "Run phpstan/phpstan"
         run: "vendor/bin/phpstan analyse --configuration=phpstan.neon"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
+/.build/
 /vendor/
-/.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -31,8 +31,11 @@ $config->getFinder()
     ->ignoreDotFiles(false)
     ->in(__DIR__)
     ->exclude([
-        '.github',
+        '.build/',
+        '.github/',
     ])
     ->name('.php_cs');
+
+$config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php_cs.cache');
 
 return $config;

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ it: coding-standards static-code-analysis tests ## Runs the coding-standards, st
 
 .PHONY: coding-standards
 coding-standards: vendor ## Fixes code style issues with friendsofphp/php-cs-fixer
+	mkdir -p .build/php-cs-fixer
 	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose
 
 .PHONY: help
@@ -11,6 +12,7 @@ help: ## Displays this list of targets with descriptions
 
 .PHONY: static-code-analysis
 static-code-analysis: vendor ## Runs a static code analysis with phpstan/phpstan
+	mkdir -p .build/phpstan
 	vendor/bin/phpstan analyse --configuration=phpstan.neon
 
 .PHONY: tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,4 @@ parameters:
 	paths:
 		- src
 		- test
+	tmpDir: .build/phpstan


### PR DESCRIPTION
This PR

* [x] uses the `.build` directory for temporary files