### PR TITLE
Enhancement: Add tests where prophesize(), willExtend(), and willImplement() are used in helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ final class ExampleTest extends Framework\TestCase
 
         // ...
     }
+
+    public function testSomethingDifferent(): void
+    {
+        $testDouble = $this->createProphecy()->reveal();
+
+        // ...
+    }
+
+    private function createProphecy()
+    {
+        return $this->prophesize(SomeModel::class);
+    }
+
 }
 ```
 
@@ -101,6 +114,18 @@ final class ExampleTest extends Framework\TestCase
 
         // ...
     }
+
+    public function testSomethingDifferent(): void
+    {
+        $testDouble = $this->createProphecy()->reveal();
+
+        // ...
+    }
+
+    private function createProphecy()
+    {
+        return $this->prophesize(SomeModel::class)->willExtend(SomeInterface::class);
+    }
 }
 ```
 
@@ -136,6 +161,18 @@ final class ExampleTest extends Framework\TestCase
         $testDouble = $this->prophecy->reveal();
 
         // ...
+    }
+
+    public function testSomethingDifferent(): void
+    {
+        $testDouble = $this->createProphecy()->reveal();
+
+        // ...
+    }
+
+    private function createProphecy()
+    {
+        return $this->prophesize(SomeModel::class)->willImplement(SomeInterface::class);
     }
 }
 ```

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,7 @@ includes:
 
 parameters:
 	ignoreErrors:
+		- '#^Method .* has no return typehint specified\.$#'
 		- '#^Property .* has no typehint specified\.$#'
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max

--- a/test/StaticAnalysis/Test/ObjectProphecy/ProphesizeTest.php
+++ b/test/StaticAnalysis/Test/ObjectProphecy/ProphesizeTest.php
@@ -64,4 +64,27 @@ final class ProphesizeTest extends Framework\TestCase
         self::assertEquals('bar', $testDouble->getFoo());
         self::assertEquals(5, $testDouble->doubleTheNumber(2));
     }
+
+    public function testCreateProphecyInHelperMethod(): void
+    {
+        $prophecy = $this->createProphecy();
+
+        $prophecy
+            ->getFoo()
+            ->willReturn('bar');
+
+        $prophecy
+            ->doubleTheNumber(Argument::is(2))
+            ->willReturn(5);
+
+        $testDouble = $prophecy->reveal();
+
+        self::assertEquals('bar', $testDouble->getFoo());
+        self::assertEquals(5, $testDouble->doubleTheNumber(2));
+    }
+
+    private function createProphecy()
+    {
+        return $this->prophesize(Src\BaseModel::class);
+    }
 }

--- a/test/StaticAnalysis/Test/ObjectProphecy/WillExtendTest.php
+++ b/test/StaticAnalysis/Test/ObjectProphecy/WillExtendTest.php
@@ -55,4 +55,23 @@ final class WillExtendTest extends Framework\TestCase
 
         self::assertSame('Hmm', $subject->baz($prophecy->reveal()));
     }
+
+    public function testCreateProphecyInHelperMethod(): void
+    {
+        $prophecy = $this->createProphecy();
+
+        $prophecy
+            ->baz()
+            ->shouldBeCalled()
+            ->willReturn('Hmm');
+
+        $subject = new Src\BaseModel();
+
+        self::assertSame('Hmm', $subject->baz($prophecy->reveal()));
+    }
+
+    private function createProphecy()
+    {
+        return $this->prophesize()->willExtend(Src\Baz::class);
+    }
 }

--- a/test/StaticAnalysis/Test/ObjectProphecy/WillImplementTest.php
+++ b/test/StaticAnalysis/Test/ObjectProphecy/WillImplementTest.php
@@ -55,4 +55,23 @@ final class WillImplementTest extends Framework\TestCase
 
         self::assertSame('Oh', $subject->bar($prophecy->reveal()));
     }
+
+    public function testCreateProphecyInHelperMethod(): void
+    {
+        $prophecy = $this->createProphecy();
+
+        $prophecy
+            ->bar()
+            ->shouldBeCalled()
+            ->willReturn('Oh');
+
+        $subject = new Src\BaseModel();
+
+        self::assertSame('Oh', $subject->bar($prophecy->reveal()));
+    }
+
+    private function createProphecy()
+    {
+        return $this->prophesize(Src\Foo::class)->willImplement(Src\Bar::class);
+    }
 }


### PR DESCRIPTION
This PR

* [x] adds tests where `prophesize()`, `willExtend()`, and `willImplement()` are used in helper methods

Related to #121.

💁‍♂ Does that make sense, @AnnaDam and @func0der? Note that this appears to work fine when not using return type declarations or DocBlocks.