### PR TITLE
Fix: Rename test methods

### DIFF
--- a/test/StaticAnalysis/Test/ObjectProphecy/ProphesizeTest.php
+++ b/test/StaticAnalysis/Test/ObjectProphecy/ProphesizeTest.php
@@ -31,7 +31,7 @@ final class ProphesizeTest extends Framework\TestCase
         $this->prophecy = $this->prophesize(Src\BaseModel::class);
     }
 
-    public function testInSetUp(): void
+    public function testCreateProphecyInSetUp(): void
     {
         $this->prophecy
             ->getFoo()
@@ -47,7 +47,7 @@ final class ProphesizeTest extends Framework\TestCase
         self::assertEquals(5, $testDouble->doubleTheNumber(2));
     }
 
-    public function testInTestMethod(): void
+    public function testCreateProphecyInTestMethod(): void
     {
         $prophecy = $this->prophesize(Src\BaseModel::class);
 

--- a/test/StaticAnalysis/Test/ObjectProphecy/WillExtendTest.php
+++ b/test/StaticAnalysis/Test/ObjectProphecy/WillExtendTest.php
@@ -30,7 +30,7 @@ final class WillExtendTest extends Framework\TestCase
         $this->prophecy = $this->prophesize()->willExtend(Src\Baz::class);
     }
 
-    public function testInSetUp(): void
+    public function testCreateProphecyInSetUp(): void
     {
         $this->prophecy
             ->baz()
@@ -42,7 +42,7 @@ final class WillExtendTest extends Framework\TestCase
         self::assertSame('Hmm', $subject->baz($this->prophecy->reveal()));
     }
 
-    public function testInTestMethod(): void
+    public function testCreateProphecyInTestMethod(): void
     {
         $prophecy = $this->prophesize()->willExtend(Src\Baz::class);
 

--- a/test/StaticAnalysis/Test/ObjectProphecy/WillImplementTest.php
+++ b/test/StaticAnalysis/Test/ObjectProphecy/WillImplementTest.php
@@ -30,7 +30,7 @@ final class WillImplementTest extends Framework\TestCase
         $this->prophecy = $this->prophesize(Src\Foo::class)->willImplement(Src\Bar::class);
     }
 
-    public function testInSetUp(): void
+    public function testCreateProphecyInSetUp(): void
     {
         $this->prophecy
             ->bar()
@@ -42,7 +42,7 @@ final class WillImplementTest extends Framework\TestCase
         self::assertSame('Oh', $subject->bar($this->prophecy->reveal()));
     }
 
-    public function testInTestMethod(): void
+    public function testCreateProphecyInTestMethod(): void
     {
         $prophecy = $this->prophesize(Src\Foo::class)->willImplement(Src\Bar::class);
 


### PR DESCRIPTION
This PR

* [x] renames test methods