### PR TITLE
Fix: Run static analysis with locked dependencies

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -76,6 +76,7 @@ jobs:
 
         dependencies:
           - "lowest"
+          - "locked"
           - "highest"
 
     steps:


### PR DESCRIPTION
This PR

* [x] runs a static analysis with locked dependencies

Follows #172.