### PR TITLE
Fix: Use appropriate secret

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: "Add labels based on branch name"
         uses: "actions/github-script@v3.0.0"
         with:
-          github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |
             const branchPrefixLabels = {
               feature: "enhancement",


### PR DESCRIPTION
This PR

* [x] uses the appropriate secret for the _Triage_ workflow