### PR TITLE
Fix: Use pull_request_target

### DIFF
--- a/.github/workflows/close.yaml
+++ b/.github/workflows/close.yaml
@@ -3,7 +3,7 @@
 name: "Close"
 
 on: # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types:
       - "opened"
       - "reopened"


### PR DESCRIPTION
This PR

* [x] uses `pull_request_target` instead of `target`

Follows #233.