### PR TITLE
Fix: Avoid use of acronyms

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-This PR
+This pull request
 
 * [x]
 * [ ]


### PR DESCRIPTION
This PR

* [x] avoids the use of acronyms