### PR TITLE
Remove problematic test case

### DIFF
--- a/phpstan-without-extension-baseline.neon
+++ b/phpstan-without-extension-baseline.neon
@@ -22,22 +22,22 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\:\\:doubleTheNumber\\(\\)\\.$#"
-			count: 2
+			count: 1
 			path: test/StaticAnalysis/Test/ObjectProphecy/ProphesizeTest.php
 
 		-
 			message: "#^Call to an undefined method Prophecy\\\\Prophecy\\\\ObjectProphecy\\:\\:getFoo\\(\\)\\.$#"
-			count: 2
+			count: 1
 			path: test/StaticAnalysis/Test/ObjectProphecy/ProphesizeTest.php
 
 		-
 			message: "#^Call to an undefined method object\\:\\:doubleTheNumber\\(\\)\\.$#"
-			count: 2
+			count: 1
 			path: test/StaticAnalysis/Test/ObjectProphecy/ProphesizeTest.php
 
 		-
 			message: "#^Call to an undefined method object\\:\\:getFoo\\(\\)\\.$#"
-			count: 2
+			count: 1
 			path: test/StaticAnalysis/Test/ObjectProphecy/ProphesizeTest.php
 
 		-

--- a/test/StaticAnalysis/Test/ObjectProphecy/ProphesizeTest.php
+++ b/test/StaticAnalysis/Test/ObjectProphecy/ProphesizeTest.php
@@ -16,7 +16,6 @@ namespace JanGregor\Prophecy\Test\StaticAnalysis\Test\ObjectProphecy;
 use JanGregor\Prophecy\Test\StaticAnalysis\Src;
 use PHPUnit\Framework;
 use Prophecy\Argument;
-use Prophecy\Prophet;
 
 /**
  * @internal
@@ -69,24 +68,6 @@ final class ProphesizeTest extends Framework\TestCase
     public function testCreateProphecyInHelperMethod(): void
     {
         $prophecy = $this->createProphecy();
-
-        $prophecy
-            ->getFoo()
-            ->willReturn('bar');
-
-        $prophecy
-            ->doubleTheNumber(Argument::is(2))
-            ->willReturn(5);
-
-        $testDouble = $prophecy->reveal();
-
-        self::assertEquals('bar', $testDouble->getFoo());
-        self::assertEquals(5, $testDouble->doubleTheNumber(2));
-    }
-
-    public function testCreateProphecyInline(): void
-    {
-        $prophecy = (new Prophet())->prophesize(Src\BaseModel::class);
 
         $prophecy
             ->getFoo()


### PR DESCRIPTION
Reverts only part of https://github.com/Jan0707/phpstan-prophecy/pull/316

Following test case produces different phpstan analyisis output depending on used versions:
```php
  public function testCreateProphecyInline(): void
    {
        $prophecy = (new Prophet())->prophesize(Src\BaseModel::class);

        $prophecy
            ->getFoo()
            ->willReturn('bar');

        $prophecy
            ->doubleTheNumber(Argument::is(2))
            ->willReturn(5);

        $testDouble = $prophecy->reveal();

        self::assertEquals('bar', $testDouble->getFoo());
        self::assertEquals(5, $testDouble->doubleTheNumber(2));
    }
```

Creating Prophet inline seems like a valid use case that should be supported as well. In combination with PHPUnit 10.0.0. this produced internal phpstan error due to following [lines](https://github.com/Jan0707/phpstan-prophecy/pull/316/files#diff-4b3651c5d7ac20569df5d397e9f73467909e76c059be6c1389ba3bf93ff4554bL69). I added the test case thus this use case is visible and supported however output is different based on combination of versions thus it is hard to support this without having version specific baseline(s).
 
More developers are reaching for this use case as PHPUnit 10 deprecated non-static data providers (see https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09). Easy way out is to use `(new Prophet())` .
