### PR TITLE
Allow PHPUnit 10 & 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "conflict": {
     "phpspec/prophecy": "<1.7.0 || >=2.0.0",
-    "phpunit/phpunit": "<6.0.0 || >=10.0.0"
+    "phpunit/phpunit": "<6.0.0 || >=12.0.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.1.1",


### PR DESCRIPTION
This pull request

- [x] Allows the installation of this package alongside PHPUnit 10 & 11 

Related to #332.

I started getting [CI failures](https://github.com/facile-it/paraunit/actions/runs/8505456069/job/23293965398#step:4:94) since 1.0.1 due to the inclusion of #332; before, the `conflict` rule was broken and allowed me to use this package happily with PHPUnit 10 and 11: https://github.com/facile-it/paraunit/actions/runs/8432471574/job/23091610492#step:4:109