### PR TITLE
Revert "Workaround to include phpspec/prophecy-phpunit#67"

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -44,7 +44,7 @@ jobs:
           php-version: "${{ matrix.php-version }}"
 
       - name: "Validate composer.json and composer.lock"
-        run: "composer validate --ansi"
+        run: "composer validate --ansi --strict"
 
       - uses: "ramsey/composer-install@v3"
         with:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "ergebnis/license": "^2.6.0",
     "ergebnis/php-cs-fixer-config": "^6.46.0",
     "phpspec/prophecy": "^1.7.0",
-    "phpspec/prophecy-phpunit": "^2.3 || dev-master#d3c2804 as 2.4.0",
+    "phpspec/prophecy-phpunit": "^2.3",
     "phpunit/phpunit": "^9.1.0"
   },
   "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5d76725bc578513d8bfbc12bac09d1df",
+    "content-hash": "482e38207603cceea2c423315a5f9f97",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -5718,9 +5718,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "phpspec/prophecy-phpunit": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
This reverts commit 5f940fa33510baa928af6518a152e5ab951ccfb2.

This pull request follows #364, needs the release of https://github.com/phpspec/prophecy-phpunit/pull/67 under a tag.